### PR TITLE
Add hairglasses-studio Ghostty shader collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can support the developers of these projects financially:
 * [erniee's Ghostty shaders](https://github.com/erniee/gshaders)
 * [Fearless Geek Shaders for Ghostty](https://github.com/fearlessgeekmedia/Fearless-Geek-Shaders-for-Ghostty)
 * [Ghostty-shaders from hackr-sh](https://github.com/hackr-sh/ghostty-shaders)
+* [hairglasses-studio Ghostty shaders](https://github.com/hairglasses-studio/dotfiles/tree/main/ghostty/shaders) - 150+ curated GLSL shaders with metadata, playlists, reusable shader libraries, and management tooling (cycle, benchmark, auto-rotate)
 
 ## Themes
 * [Another Dracula theme for Ghostty](https://github.com/dal-liu/ghostty-dracula)


### PR DESCRIPTION
Adds the [hairglasses-studio shader collection](https://github.com/hairglasses-studio/dotfiles/tree/main/ghostty/shaders) to the Shaders section.

**What it includes:**

- **150+ curated GLSL shaders** — one of the largest collections for Ghostty, organized across active, archive, and library directories
- **Structured metadata** — `shaders.toml` with per-shader metadata (author, category, performance tier, description)
- **Reusable shader libraries** — 5 GLSL includes (blend, hash, hex, noise, sdf) for building new shaders
- **Shader management tooling** — 9 shell scripts:
  - `shader-cycle` — keybind-driven shader switching with waybar integration
  - `shader-auto-rotate` — timed rotation through a playlist
  - `shader-benchmark` — FPS/performance testing per shader
  - `shader-playlist` — playlist-based shader sequencing
  - `shader-audit` / `shader-meta` — quality and metadata inspection
  - `shader-random` / `shader-build` / `shader-test`
- **Playlists** — curated shader playlists (ambient, custom)
- **SOURCES.md** — credits all upstream shader authors

The entry is placed alphabetically within the Shaders section (after "Ghostty-shaders from hackr-sh").